### PR TITLE
minor fix for a missing maven repositry in the build.gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ repositories {
         url 'https://dl.bintray.com/3dcitydb/maven'
     }
     maven {
+        url 'http://central.maven.org/maven2/'
+    }        
+    maven {
         url 'http://maven.imagej.net/content/repositories/thirdparty/'
     }
     jcenter()


### PR DESCRIPTION
While running the gradle build task, I got the following error message on my Eclispe's Gradle Executions window:

org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException: Could not HEAD 'http://maven.imagej.net/content/repositories/thirdparty/com/googlecode/efficient-java-matrix-library/core/0.26/core-0.26.jar'. Received status code 502 from server: Bad gateway: chunk-data missing trailing CRLF

This pull request tends to fix this problem. 

